### PR TITLE
Changed URL to the correct one.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  name = "github.com/go-fsnotify/fsnotify"
+  name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 
 [[constraint]]
-  name = "github.com/go-fsnotify/fsnotify"
+  name = "github.com/fsnotify/fsnotify"
   version = "1.4.7"
 
 [prune]

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-fsnotify/fsnotify"
+	"github.com/fsnotify/fsnotify"
 )
 
 var (


### PR DESCRIPTION
go-fsnotify/fsnotify was the original name of this project. The project organization was renamed from go-fsnotify to fsnotify some time ago. 

Change the dependencies from github.com/go-fsnotify/fsnotify to github.com/fsnotify/fsnotify