### PR TITLE
Various cleanups and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Watch
 Usage: ``Watch [-v] [-t]  [-p <path>] [-x <regexp>] <command>``
 
 Watches for changes in a directory tree, and runs a command when
-something changed. By default, the output goes to an acme win.
+something changed.
 
--t sends the output to the terminal instead of acme
+-t deprecated, always true.
 
 -v enables verbose debugging output
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ Watch
 
 Usage: ``Watch [-v] [-t]  [-p <path>] [-x <regexp>] <command>``
 
-Watches for changes in a directory tree, and runs a command when
-something changed.
+Watches for changes in a directory tree, and runs a command when something
+changed. Note that only changes that happen while Watch is running are
+detected. Also, a failed execution of the command is not retried.
 
 -t deprecated, always true.
 

--- a/main.go
+++ b/main.go
@@ -92,15 +92,15 @@ func main() {
 	for {
 		select {
 		case lastChange = <-changes:
-			timer.Reset(rebuildDelay)
+			if lastRun.Before(lastChange) {
+				timer.Reset(rebuildDelay)
+			}
 
 		case <-ui.rerun():
 			lastRun = run(ui)
 
 		case <-timer.C:
-			if lastRun.Before(lastChange) {
-				lastRun = run(ui)
-			}
+			lastRun = run(ui)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -85,9 +85,10 @@ func main() {
 	}
 
 	timer := time.NewTimer(0)
+	<-timer.C // Avoid to run command just after startup.
 	changes := startWatching(*watchPath)
-	lastRun := time.Time{}
-	lastChange := time.Now()
+	lastRun := time.Now()
+	lastChange := lastRun
 
 	for {
 		select {

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	debug     = flag.Bool("v", false, "Enable verbose debugging output")
-	term      = flag.Bool("t", true, "Run in a terminal (deprecated, always true)")
+	_         = flag.Bool("t", true, "Run in a terminal (deprecated, always true)")
 	exclude   = flag.String("x", "", "Exclude files and directories matching this regular expression")
 	watchPath = flag.String("p", ".", "The path to watch")
 )
@@ -164,13 +164,6 @@ func wait(start time.Time, cmd *exec.Cmd) int {
 				return status.ExitStatus()
 			}
 		}
-	}
-}
-
-func kill() {
-	select {
-	case killChan <- time.Now():
-		debugPrint("Killing")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -90,6 +90,9 @@ func main() {
 
 func run() time.Time {
 	cmd := exec.Command(flag.Arg(0), flag.Args()[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
+
 	if hasSetPGID {
 		var attr syscall.SysProcAttr
 		reflect.ValueOf(&attr).Elem().FieldByName(setpgidName).SetBool(true)

--- a/main.go
+++ b/main.go
@@ -209,7 +209,7 @@ func sendChanges(w *fsnotify.Watcher, changes chan<- time.Time) {
 			}
 			time, err := modTime(ev.Name)
 			if err != nil {
-				log.Printf("Failed to get even time: %s", err)
+				log.Printf("Failed to get event time: %s", err)
 				continue
 			}
 


### PR DESCRIPTION
Hi @bboreham , I hope you are still the person to direct PRs to. (And I assume that this Weaveworks fork is the most alive fork of Watch.)

At Grafana Labs, we ran into an issue with more complex config maps (where Watch has to watch whole directories). For reasons that I don't fully understand (perhaps related to how K8s manages configmaps, or some kernel specifics), fsnotify emits a regular stream of CHMOD events with timestamps in the past. With the current code, an older event coming in just after a recent event can mask the timestamp of the newer event. In that case, the update is completely missed, and Watch doesn't run the configured command.

I think I found a fix (in commit 734a28f).

At the same time, I was confused that Watch will always run the configured command on startup. This could be deliberate, as in "we are conservative, perhaps something happened while Watch was restarting". However, especially if the reload command is expensive or in other ways invasive, you might not want to trigger the reload "just in case". I changed the code to only run the configured command after positively detecting a recent event via fsnotify. If that's against the idea behind it, I can remove that part.

Furthermore, I fixed a typo and removed dead code.

Thanks for your review.

@captncraig FYI