### PR TITLE
Update base image to alpine:3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 RUN apk add --no-cache curl
 ADD Watch /
 ENTRYPOINT ["/Watch"]


### PR DESCRIPTION
Needs a rebuild anyway to pickup the latest patch release on the current 3.12 which carries high vulnerabilities - may as well bump it now.