### PR TITLE
fix: curl needs to be included in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY . /app
 RUN go build -v -o /build /app
 
 FROM alpine:3.15
+RUN apk add --no-cache curl
 RUN mkdir /build
 COPY --from=builder /build .
 


### PR DESCRIPTION
This issue was introduced in https://github.com/weaveworks/Watch/pull/9/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557

Running `weaveworks/watch:master-f8e2469` I noticed:

    2022/05/25 07:46:00 DEBUG: syscall.SysProcAttr.Setpgid exists and is a bool
    2022/05/25 07:46:00 DEBUG: Watching /path/to/config.yml
    2022/05/25 07:51:09 DEBUG: "/path/to/config.yml": CHMOD at 2022-05-25 07:51:09.191435529 +0000 UTC
    2022/05/25 07:51:09 DEBUG: "/path/to/config.yml": REMOVE at 2022-05-25 07:51:09.191435529 +0000 UTC
    curl -X POST --fail -o - -sS http://localhost:80/-/reload
    fatal: exec: "curl": executable file not found in $PATH

This was working on the previous version: `weaveworks/watch:master-5fc29a9`